### PR TITLE
Use PIL for image formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ local.properties
 android.iml
 .gradle/
 android/assets/*
+.ropeproject/
+downloads/

--- a/scripts/check_images.py
+++ b/scripts/check_images.py
@@ -1,23 +1,25 @@
 import os
+
 from PIL import Image
 
 img_dir = "downloads"
 for filename in os.listdir(img_dir):
     filepath = os.path.join(img_dir, filename)
-    print('file folder >>>>>'+filepath)
+    print('file folder >>>>>' + filepath)
     if filename == ".DS_Store":
         #print('DS folder -----'+filepath)
         os.remove(filepath)
     else:
         for imagename in os.listdir(filepath):
-            
-            imagepath = os.path.join(filepath,imagename)
-            try :
+
+            imagepath = os.path.join(filepath, imagename)
+            try:
                 with Image.open(imagepath) as im:
-                     n=1
-            except :
+                    n = 1
+                    if im.format != "JPEG":
+                        os.remove(imagepath)
+            except:
                 print(imagepath)
                 os.remove(imagepath)
             if len(imagepath) > 220:
                 os.remove(imagepath)
-


### PR DESCRIPTION
This fixes a bug where `webm` format images, which download with the extension `.jpg` cause an error during training. Now image formats are checked using PIL when running `check_images.py`, and images that are not JPEG format are removed from the image directory.